### PR TITLE
Use CSS in the generated matrix html, show compilation failures as '?'

### DIFF
--- a/src/ag/gitolite/HtmlGen.scala
+++ b/src/ag/gitolite/HtmlGen.scala
@@ -9,7 +9,9 @@ import java.time.ZonedDateTime
 import java.time.ZoneId
 
 trait HtmlContext {
+  def doctype(): Unit
   def start(tag: String, attributes: Seq[(String, String)]): Unit
+  def start_self_closing(tag: String, attributes: Seq[(String, String)]): Unit
   def text(s: String): Unit
   def end(tag: String): Unit
 }
@@ -18,12 +20,24 @@ class FileContext(path: os.Path) extends HtmlContext with AutoCloseable {
 
   val w = new FileWriter(path.toIO).nn
 
+  def doctype(): Unit = {
+    w.write("<!DOCTYPE html>")
+  }
+
   def start(tag: String, attributes: Seq[(String, String)]): Unit = {
     w.write(s"<$tag")
     attributes.foreach { (k, v) =>
       w.write(s" $k='$v'")
     }
     w.write(">")
+  }
+
+  def start_self_closing(tag: String, attributes: Seq[(String, String)]): Unit = {
+    w.write(s"<$tag")
+    attributes.foreach { (k, v) =>
+      w.write(s" $k='$v'")
+    }
+    w.write("/>")
   }
 
   def text(s: String): Unit = {
@@ -39,6 +53,8 @@ class FileContext(path: os.Path) extends HtmlContext with AutoCloseable {
   }
 }
 
+val self_closing_tags = Set("meta")
+
 case class Element(tag: String, attributes: Seq[(String, String)]) {
   def attr(name: String, value: String | Null): Element = value match {
     case s: String => this.copy(attributes = attributes :+ (name, s))
@@ -52,15 +68,23 @@ case class Element(tag: String, attributes: Seq[(String, String)]) {
     attr("href", c)
   def style(c: String | Null): Element =
     attr("style", c)
+  def css_class(c: String | Null): Element =
+    attr("class", c)
+  def css_class(c: List[String]): Element =
+    attr("class", c.mkString(" "))
   def textAlign(c: String | Null): Element =
     attr("textAlign", c)
   def title(c: String | Null): Element =
     attr("title", c)
 
   def apply(f: HtmlContext ?=> Any)(using c: HtmlContext): Unit = {
-    c.start(tag, attributes)
-    f(using c)
-    c.end(tag)
+    if (self_closing_tags.contains(tag)) {
+      c.start_self_closing(tag, attributes)
+    } else {
+      c.start(tag, attributes)
+      f(using c)
+      c.end(tag)
+    }
   }
 }
 
@@ -81,8 +105,13 @@ val table = Element()
 val td = Element()
 val tr = Element()
 val script = Element()
+val style = Element()
+val head = Element()
+val meta = Element()
+val title = Element()
 
 def html[A](c: HtmlContext)(f: HtmlContext ?=> A): A = {
+  c.doctype()
   c.start("html", Seq())
   val a = f(using c)
   c.end("html")
@@ -97,7 +126,7 @@ def text(s: String)(using c: HtmlContext): Unit = {
 class HtmlGen(p: Project) {
 
   val displayFormat: DateTimeFormatter =
-    DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm").nn
+    DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm (EEEE)").nn
 
 
   val gen_html =
@@ -147,10 +176,8 @@ class HtmlGen(p: Project) {
             val fileName = s"$t.$ext"
 
             td {
-              pre {
-                a.href(s"${p.tests_repo_name}/$t.$ext").title(fileName) {
-                  text(ch.toString)
-                }
+              a.href(s"${p.tests_repo_name}/$t.$ext").title(fileName) {
+                text(ch.toString)
               }
             }
         }
@@ -172,7 +199,7 @@ class HtmlGen(p: Project) {
         }
 
         // Display the results table
-        def tbl(using HtmlContext) = table {
+        def tbl(using HtmlContext) = table.css_class("results") {
             /* 3 headers */
             for (i <- 0 to 2) {
               tr {
@@ -192,32 +219,28 @@ class HtmlGen(p: Project) {
 
               val is_mine = false // outcome.is_mine
               val is_late = result.prepare_info.commit_time.isAfter(ZonedDateTime.of(code_cutoff, ZoneId.systemDefault()))
-              tr.bgcolor(if (is_mine) "yellow" else null) {
-                td {
-                  pre.title(sha) {
-                    if (is_late) text(s"$short_name*")
-                    else text(short_name)
-                  }
+              tr.css_class(if (is_mine) "mine" else null) {
+                td.title(sha) {
+                  if (is_late) text(s"$short_name*")
+                  else text(short_name)
                 }
                 td {
-                  pre.textAlign("right") {
-                    text("")
-                  }
+                  text("")
                 }
                 testNames.foreach { t =>
-                  td.bgcolor(if (chosen.contains(t.external_name)) "LightGray" else null) {
-                    val (the_style, the_text) =
-                      outcome.get(t.external_name).flatMap(_.outcome) match {
-                        case Some("pass") =>
-                          ("color:green", ".")
-                        case Some(_) =>
-                          ("color:red", "X")
-                        case _ =>
-                          (null, "?")
-                      }
-                    pre.textAlign("center").style(the_style) {
-                      text(the_text)
+                  val (status_class, the_text) =
+                    outcome.get(t.external_name).flatMap(_.outcome) match {
+                      case Some("pass") =>
+                        ("pass", ".")
+                      case Some(_) =>
+                        ("fail", "X")
+                      case None =>
+                        ("compilefail", "?")
                     }
+                  val chosen_class = if (chosen.contains(t.external_name)) List("chosen") else List.empty
+                  val the_class = List(status_class) ::: chosen_class
+                  td.css_class(the_class) {
+                    text(the_text)
                   }
                 }
               }
@@ -244,27 +267,40 @@ class HtmlGen(p: Project) {
           }
 
         def weights_table(using HtmlContext) = table {
-            tr { td { h3 { pre { text("Weights") } } } }
+            tr { td { h3 { pre { text("Selected test weights") } } } }
             tr {
               td {
-                table {
-                  chosen.foreach { c =>
+                table.css_class("weights") {
+                  tr {
+                    td.style("font-weight: bold;") { text("test") }
+                    td.style("font-weight: bold;") { text("weight") }
+                  }
+                  var total_weight = 0
+
+                  // Match the sorting of test cases elsewhere (t0-4 before user test cases)
+                  val sorted = chosen.toList.sortBy(c => (c.length, c))
+                  sorted.foreach { c =>
                     val weight = weights.find { w =>
                       scala.util.matching.Regex(w.pattern).matches(c)
-                    } match {
+                    }
+                    total_weight += (weight match {
+                      case Some(w) => w.weight
+                      case None => 0
+                    })
+
+                    val weight_str = weight match {
                       case Some(w) => w.weight.toString
                       case None => "?"
                     }
                     tr {
-                      td {
-                        pre {
-                          text(c)
-                        }
-                      }
-                      td {
-                        text(weight)
-                      }
+                      td { text(c) }
+                      td { text(weight_str) }
                     }
+                  }
+
+                  tr {
+                    td.style("font-weight: bold;") { text("total") }
+                    td { text(total_weight.toString) }
                   }
                 }
               }
@@ -282,16 +318,51 @@ class HtmlGen(p: Project) {
           scala.util.Using(FileContext(f)) { file =>
 
             html(file) {
-              //head(
-              //    script(src = "https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js" )
-              //),
+              head {
+                meta.attr("charset", "utf8") { }
+                meta.attr("name", "viewport").attr("content", "width=device-width,initial-scale=1") { }
+                title(text(s"${p.course.course_name}_${p.project_name}"))
+                style(text("""
+.pass { color: green; }
+.fail { color: red; }
+.compilefail { color: #933; }
+.chosen { background-color: #DDD; }
+.mine, .mine td { background-color: hsl(53.5, 100%, 71.2%) !important; }
+
+h3, pre { margin: 0; }
+h1 { margin: 0 0 0.67em 0; }
+
+.results { font-family: monospace; }
+.weights { font-family: monospace; }
+.weights td:first-child { padding-right: 0.5em; }
+.weights td:nth-child(2) { text-align: right; }
+
+.results td:nth-child(2) { border-right: 1px solid #CCC; }
+.results tr:nth-child(3) { border-bottom: 1px solid #CCC; }
+
+/* Alternating row styles: */
+.results { border-collapse: collapse; }
+.results td { padding: 2px; }
+.results tr:nth-child(2n) { background: #FFF; }
+.results tr:nth-child(2n + 5) { background: #F5F5F5; }
+.results tr:nth-child(2n) .chosen { background: hsl(120, 0%, 95%); }
+.results tr:nth-child(2n + 5) .chosen { background: hsl(120, 0%, 88%); }
+
+/* Original (unintentional) spacing: */
+/* .results td { padding-bottom: calc(1em + 1px); } */
+
+/* More relaxed spacing: */
+.results td { padding: 0.15em 0.3em; }
+"""))
+                // script(src = "https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js" )
+              }
               body {
                 table {
                   tr(td(h1(text(s"${p.course.course_name}_${p.project_name}"))))
                   tr(td(times))
                   tr(td(tbl))
                   tr(td(text("")))
-                  tr(td(text(s"${enrollment.keySet.size} enrollements")))
+                  tr(td(text(s"${enrollment.keySet.size} enrollments")))
                   tr(td(text(s"${submissions.size} submissions")))
                   tr(td(text(s"${testNames.size} tests")))
                   tr {
@@ -306,6 +377,15 @@ class HtmlGen(p: Project) {
                   }
                 }
                 //script.src("highlight_on_click.js")
+                script(text("""
+// Highlight row when its alias/hash is clicked
+document.querySelectorAll(".results td[title]")
+  .forEach((e) => {
+    e.addEventListener("click", () => {
+      e.parentElement.classList.toggle("mine");
+    })
+  });
+"""))
               }
             }
           }


### PR DESCRIPTION
- Makes compilation failures visible as dark red '?'s on the matrix
- Fix text alignment in the test case weight table
- Add alternating row backgrounds to make the matrix easier to read
- Minor changes to padding of matrix rows
- Add small amount of javascript code to highlight rows when clicking the alias/commit hash