### PR TITLE
Fix cache path for Project.get_aliases

### DIFF
--- a/src/ag/grader/Project.scala
+++ b/src/ag/grader/Project.scala
@@ -616,7 +616,7 @@ case class Project(course: Course, project_name: String) derives ReadWriter {
     }
 
   lazy val get_aliases: Maker[SortedMap[CSID, Alias]] =
-    Rule(Gitolite.mirror(aliases_repo_name), null) {
+    Rule(Gitolite.mirror(aliases_repo_name), scope) {
       aliases =>
         val path = aliases.path / "aliases.json"
         if (os.isFile(path)) {


### PR DESCRIPTION
Fixes #5, but note that this may break existing runs (before the cache is cleared) due to another bug: https://github.com/utgheith/grader/issues/5#issuecomment-2364975688

The specific compat issue is that the original rule created `workspace/targets/ag/gitolite/Project/get_aliases` as a file to track its status, but then changing it to `get_aliases/cs439t_f24/p1` requires that `get_aliases` becomes a directory; the tracker doesn't handle that case.