### PR TITLE
Add `--code-cuttoff` argument to specify which commit to run, add `late_commits` subcommand

### DIFF
--- a/src/ag/grader/LateCommit.scala
+++ b/src/ag/grader/LateCommit.scala
@@ -1,0 +1,7 @@
+package ag.grader
+
+import upickle.default.ReadWriter
+import java.time.{ZonedDateTime, Duration}
+import ag.rules.{given_ReadWriter_ZonedDateTime, given_ReadWriter_Duration}
+
+final case class LateCommit(hash: String, time: ZonedDateTime, delay: Duration, message: String) derives ReadWriter

--- a/src/ag/rules/extensions.scala
+++ b/src/ag/rules/extensions.scala
@@ -5,7 +5,7 @@ import upickle.default.{ReadWriter, readwriter}
 import java.nio.charset.{Charset, StandardCharsets}
 import java.security.MessageDigest
 import scala.collection.{SortedMap, SortedSet}
-import java.time.LocalDateTime
+import java.time.{Duration, LocalDateTime}
 import java.time.format.DateTimeFormatter
 import java.util.concurrent.Semaphore
 import java.util.concurrent.atomic.AtomicLong
@@ -59,6 +59,11 @@ given ReadWriter[ZonedDateTime] = readwriter[(LocalDateTime, ZoneId)].bimap[Zone
   zdt => (zdt.toLocalDateTime, zdt.getZone),
   pair => ZonedDateTime.of(pair._1, pair._2)
 )
+
+//////// ReadWriter for ZonedDateTime //////
+
+given ReadWriter[Duration] = readwriter[String]
+  .bimap[Duration](dur => dur.toString, str => Duration.parse(str))
 
 /*****************/
 /* MessageDigest */


### PR DESCRIPTION
`--code-cutoff` controls which commit is selected for preparing and running test cases, if not specified in a `commit_id` file.  If the argument is not provided, no cutoff is used (equivalent to `--code-cutoff none`).

Values:
- 'none': no cutoff, use most recent commit
- 'default' or 'deadline': use the code deadline specified in the project config, use the last commit before the deadline.
- a specific ISO 8601 datetime; use the last commit before that time. (example: "2024-09-19T18:23:00")

The `late_commits` subcommand lists all commits after the specified code cutoff (using the above semantics).