### PR TITLE
Disable git templates to reduce cache size on disk

### DIFF
--- a/src/ag/grader/Gitolite.scala
+++ b/src/ag/grader/Gitolite.scala
@@ -66,7 +66,7 @@ object Gitolite {
           case NonFatal(_) =>
             os.remove.all(dir)
             os.makeDir.all(dir)
-            server.SshProc("git", "clone", server.git_uri(repo), ".").run(cwd = dir)
+            server.SshProc("git", "clone", "--template=", server.git_uri(repo), ".").run(cwd = dir)
         }
         true
       case (_, _) =>

--- a/src/ag/grader/Project.scala
+++ b/src/ag/grader/Project.scala
@@ -266,6 +266,7 @@ case class Project(course: Course, project_name: String) derives ReadWriter {
             "git",
             "clone",
             "--shared",
+            "--template=",
             "--no-checkout",
             submission_repo.path,
             dir
@@ -370,6 +371,7 @@ case class Project(course: Course, project_name: String) derives ReadWriter {
             "git",
             "clone",
             "--shared",
+            "--template=",
             "--no-checkout",
             submission_repo.path,
             dir
@@ -619,7 +621,7 @@ case class Project(course: Course, project_name: String) derives ReadWriter {
       case (dir, (Some(submission), test_extensions, test_cutoff)) =>
         os.remove.all(dir)
         // clone, no checkout
-        val _ = os.proc("git", "clone", submission.path, "--no-checkout", dir).run(cwd = os.pwd)
+        val _ = os.proc("git", "clone", submission.path, "--shared", "--template=", "--no-checkout", dir).run(cwd = os.pwd)
         // find the latest commit after the cutoff
         val rev = os.proc("git", "rev-list", "-n", "1", "--first-parent", "--until", test_cutoff.toString, "master").lines(cwd = dir).head.trim.nn
         // get a list of top level file names

--- a/src/ag/grader/RepoInfo.scala
+++ b/src/ag/grader/RepoInfo.scala
@@ -23,7 +23,7 @@ case class RepoInfo(server: RemoteServer, repo_name: String, latest: Option[Opti
         os.makeDir.all(path)
         try {
           say(s"cloning ${repo_name}")
-          server.SshProc("git", "clone", server.git_uri(repo_name), ".").run(cwd = path)
+          server.SshProc("git", "clone", "--template=", server.git_uri(repo_name), ".").run(cwd = path)
         } catch {
           case NonFatal(_) =>
             /* Least common path: the repo doesn't exists, fork it then clone it */
@@ -43,7 +43,7 @@ case class RepoInfo(server: RemoteServer, repo_name: String, latest: Option[Opti
               server.SshProc("ssh", server.ssh_uri, "perms", repo_name, "+", "WRITERS", w).run(os.pwd)
             }
             say(s"cloning $repo_name")
-            server.SshProc("git", "clone", server.git_uri(repo_name), ".").run(cwd = path)
+            server.SshProc("git", "clone", "--template=", server.git_uri(repo_name), ".").run(cwd = path)
         }
     }
 


### PR DESCRIPTION
Many rules clone the student repositories to do work, using --shared to reduce duplication; this leaves most repositories basically empty, only taking up space for the directory structure (on my system, about 96KiB per cloned repo).  However, by default git copies some disabled template hooks into every repository, significantly increases the resulting size.  (The contents of the default template are system-dependent, but on my system it was an issue.)

This change makes git ignore the templates folder to minimize the size of the generated repositories.