### PR TITLE
Further improvements to matrix: sticky header, dark mode support, and ability to pin tests/impls

### DIFF
--- a/src/ag/grader/HtmlGen.scala
+++ b/src/ag/grader/HtmlGen.scala
@@ -460,6 +460,128 @@ document.querySelectorAll(".results td[title]")
     })
   });
 """))
+
+                // Script to allow pinning certain cases to the left side of the matrix
+                style(text("""
+.selectors td { padding: 0; text-align: center; }
+.selectors input { margin: 0; }
+.row-pin { padding: 0; }
+.row-pin input { margin: 0; }
+"""))
+                script(text("""
+let assignment = document.querySelector("h1").textContent;
+let config_key = `~gheith/${assignment}.html#config`;
+let config = JSON.parse(window.localStorage.getItem(config_key) || "{}");
+config.pinned_tests = config.pinned_tests || {};
+config.pinned_aliases = config.pinned_aliases || {};
+
+function saveConfig() {
+  window.localStorage.setItem(config_key, JSON.stringify(config));
+}
+
+let table = document.querySelector(".results");
+let head = table.querySelector("thead");
+let body = table.querySelector("tbody");
+
+let first_header_row = head.querySelector("tr:first-child");
+let first_body_row = body.querySelector("tr:first-child");
+let selectors;
+let base_col_idx = 2;
+
+// Sort the columns of a table; if initial_index is specified,
+// assumes that only that column has moved for performance.
+function sortTableColumns(initial_index) {
+  let selector_cells = selectors.children;
+  let first_row_cells = first_body_row.children;
+  let columns = Array.from(first_header_row.children)
+    .map((cell, i) => [
+      i,
+      cell.dataset.id || "",
+      first_row_cells[i].classList.contains("chosen"),
+      selector_cells[i].firstElementChild?.checked || false,
+    ])
+    .sort(([ai, aid, achosen, aselected], [bi, bid, bchosen, bselected]) => {
+      return (+(bi < base_col_idx) - +(ai < base_col_idx)) || (+bselected - +aselected)
+        || (+bchosen - +achosen) || (aid.length - bid.length)
+        || aid.localeCompare(bid);
+    });
+
+  table.style.display = "none";
+  if (initial_index != undefined) {
+    let dest_index;
+    columns.forEach(([i,], j) => {
+      if (initial_index == i) dest_index = j;
+    });
+    if (dest_index >= initial_index) dest_index += 1;
+
+    table.querySelectorAll("tr").forEach((row) => {
+      row.insertBefore(row.children[initial_index], row.children[dest_index]);
+    });
+  } else {
+    table.querySelectorAll("tr").forEach((row) => {
+      let children = Array.from(row.children);
+      let reordered_children = columns.map(([i,]) => children[i]);
+      row.replaceChildren(...reordered_children);
+    });
+  }
+  table.style.display = "initial";
+}
+
+// Create a row of checkboxes to set whether each column is pinned
+selectors = document.createElement("tr");
+selectors.classList.add("selectors");
+for (let i = 0; i < first_header_row.childElementCount; i++) {
+  let cell = document.createElement("td");
+  if (i >= base_col_idx) {
+    let id = first_header_row.children[i].dataset.id;
+    let input = document.createElement("input");
+    input.type = "checkbox";
+    input.checked = config.pinned_tests[id] || false;
+    input.addEventListener("change", () => {
+      config.pinned_tests[id] = input.checked;
+      sortTableColumns(Array.prototype.indexOf.call(selectors.children, cell));
+      saveConfig();
+    });
+    cell.appendChild(input);
+  }
+  if (i == 0) {
+    cell.classList.add("alias");
+    cell.textContent = "pinned:";
+  }
+  selectors.appendChild(cell);
+}
+head.appendChild(selectors);
+sortTableColumns();
+
+function sortRows(element) {
+  let sorted = Array.from(element.children)
+    .sort((a, b) => (a.dataset.alias || "").localeCompare(b.dataset.alias || ""));
+  element.replaceChildren(...sorted);
+}
+// Create a column of checkboxes to set whether each row is pinned
+table.querySelectorAll("tr").forEach((row) => {
+  let cell = document.createElement("td");
+  cell.classList.add("row-pin");
+  if (row.parentElement == body) {
+    let input = document.createElement("input");
+    input.type = "checkbox";
+    input.checked = config.pinned_aliases[row.dataset.alias] || false;
+    if (input.checked) head.appendChild(row);
+
+    input.addEventListener("change", () => {
+      let target = input.checked ? head : body;
+      target.appendChild(row);
+      sortRows(target);
+      config.pinned_aliases[row.dataset.alias] = input.checked;
+      saveConfig();
+    });
+    cell.appendChild(input);
+  }
+  row.insertBefore(cell, row.firstChild);
+});
+base_col_idx = 3;
+sortRows(head);
+"""))
               }
             }
           }


### PR DESCRIPTION
- Makes the header and left side "sticky" (ie. always visible even when scrolled down on the page)

- Adds basic support for a dark mode using CSS; this detects the sysem color scheme, and if dark mode is requested, switches to a dark color scheme.

- Adds script to allow pinning specific implementations or test cases.  This allows students to pin their own implementation and the test cases that they are focusing on, without having to re-find them on the matrix each time.  (It's also useful when writing a test case, to make it easier to see how many people are passing it.)

Note that the pinning script is currently embedded in the generated HTML, which is fine for simplicity, but it's also embedded in the Scala source code.  It may be worth moving the source code for it into a separate file -- if so, where should it be put?