### PR TITLE
Add staff highlighting on a per-project basis

### DIFF
--- a/src/ag/grader/HtmlGen.scala
+++ b/src/ag/grader/HtmlGen.scala
@@ -143,7 +143,8 @@ class HtmlGen(p: Project) {
         p.code_cutoff *:
         p.course.enrollment *:
         p.anti_aliases *:
-        p.course.staff,
+        p.course.staff *:
+        p.staff,
       p.scope
     ) {
       case (
@@ -157,7 +158,8 @@ class HtmlGen(p: Project) {
             code_cutoff,
             enrollment,
             anti_aliases,
-            staff
+            course_staff,
+            project_staff
           ) =>
         val test_extensions = test_extensions_.to(IndexedSeq)
 
@@ -240,7 +242,7 @@ class HtmlGen(p: Project) {
                 result.outcomes.map { case (k, v) => (k.external_name, v) }
 
               val is_mine = anti_aliases.get(alias) match {
-                case Some(csid) => staff.contains(csid)
+                case Some(csid) => course_staff.contains(csid) || project_staff.contains(csid)
                 case None       => false
               }
               val is_late = result.prepare_info.commit_time.isAfter(

--- a/src/ag/grader/Project.scala
+++ b/src/ag/grader/Project.scala
@@ -44,7 +44,8 @@ case class RawProject(
     bad_tests: Seq[String],
     docker_file: Option[String],
     test_extensions: Seq[String],
-    weights: Seq[Weight]
+    weights: Seq[Weight],
+    staff: Seq[CSID]
 ) derives ReadWriter
 
 enum CutoffTime:
@@ -118,6 +119,11 @@ case class Project(course: Course, project_name: String) derives ReadWriter {
 
   lazy val project_repo: Maker[SignedPath[Boolean]] =
     Gitolite.mirror(project_repo_name)
+
+  lazy val staff: Maker[SortedSet[CSID]] =
+    Rule(info, scope) { p => 
+      SortedSet(p.staff*)
+    }
 
   ///////////////////
   /* Override Repo */


### PR DESCRIPTION
Allows us to choose whether to highlight our submissions for the whole course, or just for a single project. For example, Gheith's implementation could be highlighted at a global course level, while a TA could choose whether or not to highlight their submission for a given project. Would require adding a "staff" field to each project in courses.json in the courses_config repo. For example, { "courseid": { "pX": { ... "staff": ["csid1", "csid2"] } } }