### PR TITLE
Semi-automatically create `courseid__grades` repo for grading data

### DIFF
--- a/src/main.scala
+++ b/src/main.scala
@@ -236,6 +236,16 @@ object Main {
   }
 
   @main
+  def create_grades_repos(commonArgs: CommonArgs): Unit = {
+    val m = MyMonitor()
+    given State = State.of(commonArgs.workspace, m)
+    for (c <- commonArgs.selected_courses.value) {
+      println(s"Creating ${c.course_name}__grades")
+      val _ = c.create_grades_repo.value
+    }
+  }
+
+  @main
   def courses(commonArgs: CommonArgs): Unit = {
     val m = MyMonitor()
     given State = State.of(commonArgs.workspace, m)


### PR DESCRIPTION
Add logic for creating a `__grades` repository to synchronize assignment grading data between TAs, for use in grading scripts.

We can discuss this in our meeting today; the main justification is that Canvas has unreliable synchronization when accessed by multiple teachers; this lets us make uploading grades to Canvas idempotent and avoid potentially overwriting other TAs' changes.  It also lets us preserve the structure of the underlying data, rather than trying to serialize data through canvas comments.

This hasn't been tested yet, as my account does not have permission to create new repos in gitolite.

Also, is there a command to put this in to make sure that this gets run at least once when a course is set up?  It may be worth adding something like a `course_init` subcommand to group these sorts of once-per-class actions.
