### PR TITLE
Replace colons with underscores in CutoffTime labels

### DIFF
--- a/src/ag/grader/Project.scala
+++ b/src/ag/grader/Project.scala
@@ -59,6 +59,7 @@ enum CutoffTime:
       time
         .withZoneSameInstant(ZoneId.systemDefault)
         .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+        .replace(":", "_")
     case Default => "deadline"
     case None    => "latest"
 


### PR DESCRIPTION
This fixes a makefile error where it is having an error regarding `multiple target patterns` due to having colons in the path. It replaces colons with underscores in the label for a CutoffTime so that when it is added into the SignedPath it is a valid directory name to use with make.