### PR TITLE
Include graded commit sha in the json output

### DIFF
--- a/src/main/scala/ag/grader/Outcome.scala
+++ b/src/main/scala/ag/grader/Outcome.scala
@@ -26,7 +26,8 @@ case class Outcome(
     test_id: TestId,
     outcome: Option[OutcomeStatus],
     time: Option[Double],
-    tries: Int
+    tries: Int,
+    commit_id: Option[String]
 ) derives ReadWriter {
   lazy val redacted: RedactedOutcome = RedactedOutcome(
     project = project,

--- a/src/main/scala/ag/grader/Project.scala
+++ b/src/main/scala/ag/grader/Project.scala
@@ -689,7 +689,8 @@ case class Project(course: Course, project_name: String) derives ReadWriter {
               Some(outcome),
               // In the case of a timeout, show the outer runtime
               time = qemu_runtime.orElse(run_time),
-              tries = n
+              tries = n,
+              prepared.data.map(_.sha)
             )
           }
         }

--- a/src/main/scala/main.scala
+++ b/src/main/scala/main.scala
@@ -758,9 +758,17 @@ object Main {
               .map((test_id, runs) => {
                 val passed = runs.count(_.outcome.contains(OutcomeStatus.pass))
                 val total = runs.size
-                (test_id.external_name, (passed, total))
+                (test_id.external_name, ujson.Arr(passed, total))
               })
-            (csid.toString(), test_results)
+              .toMap()
+            val commit_id = outcomes(0).commit_id.getOrElse("")
+            (
+              csid.toString(),
+              Map(
+                "commit_id" -> ujson.Str(commit_id),
+                "results" -> ujson.Obj.from(test_results)
+              )
+            )
           })
           .toMap()
 


### PR DESCRIPTION
Changes the json output of running correctness. Now includes the commit sha of the submission which will be used in the Python script to validate against the __grades repo.

Previous format:
```json
{
    "<csid>": {
        "<test case>": [ <pass>, <total> ]
    }
}
```

New format:
```json
{
    "<csid>": {
        "commit_id": "<sha>",
        "results": {
            "<test case>": [ <pass>, <total> ]
        }
    }
}
```